### PR TITLE
list devDependencies in package.json

### DIFF
--- a/build/mbdatepicker.js
+++ b/build/mbdatepicker.js
@@ -6,7 +6,7 @@
     * @name materialDatePickerApp
     * @description
     * # materialDatePickerApp
-    *
+   #
     * Main module of the application.
    */
   var app;
@@ -68,9 +68,9 @@
             scope.maxDate = moment(scope.maxDate, scope.dateFormat);
           }
           getWeeks = function(monthLength, startDay, month) {
-            var chunk_size, day, monthDays, newDate, start, weeks, _i;
+            var chunk_size, day, j, monthDays, newDate, ref, start, weeks;
             monthDays = [];
-            for (day = _i = 0; 0 <= monthLength ? _i <= monthLength : _i >= monthLength; day = 0 <= monthLength ? ++_i : --_i) {
+            for (day = j = 0, ref = monthLength; 0 <= ref ? j <= ref : j >= ref; day = 0 <= ref ? ++j : --j) {
               start = moment(startDay);
               newDate = start.add(day, 'd');
               if (scope.minDate && moment(newDate, scope.dateFormat) <= moment(scope.minDate, scope.dateFormat)) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "dependencies": {
     "moment": "~2.9.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-contrib-coffee": "^0.13.0",
+    "grunt-contrib-copy": "^0.8.0"
+  },
   "engines": {},
   "scripts": {},
   "description": "![Alt text](http://i.imgur.com/zAlNOIe.png)",


### PR DESCRIPTION
Since they weren't listed, if you went

```shell
$ npm install
$ grunt build
```

it wouldn't work, since `grunt`, and the necessary plugins, weren't installed locally.

Also, I'm guessing since you probably had `grunt` and `grunt-contrib-coffee` installed globally, that you were on a slightly older version of `grunt-contrib-coffee`, which is why `build/mbdatepicker.js` changed on this PR. Once again, this is only a guess :smile_cat: 