### PR TITLE
Implemented optional UTC mode

### DIFF
--- a/app/scripts/mbdatepicker.coffee
+++ b/app/scripts/mbdatepicker.coffee
@@ -34,7 +34,8 @@ app.directive('mbDatepicker', ['$filter', ($filter)->
     inputName: '@'
     placeholder: '@'
     arrows: '=?'
-    calendarHeader: '=?'
+    calendarHeader: '=?',
+    utcMode: '=' # UTC mode can be used for fixed dates that should never be converted to local timezones (e.g., birth dates)
   }
   template: '
             <div id="dateSelectors" class="date-selectors"  outside-click="hidePicker()">
@@ -80,14 +81,19 @@ app.directive('mbDatepicker', ['$filter', ($filter)->
 # Vars
     selectors = document.querySelector('#dateSelectors')
     today = moment()
+    if scope.utcMode then today.utc()
     scope.month = '';
     scope.year = today.year();
 
     # Casual definition
     if scope.inputClass then selectors.className = selectors.className + " " + scope.inputClass
     if !scope.dateFormat then scope.dateFormat = "YYYY-MM-DD"
-    if scope.minDate then scope.minDate = moment(scope.minDate, scope.dateFormat)
-    if scope.maxDate then scope.maxDate = moment(scope.maxDate, scope.dateFormat)
+    if scope.minDate
+      scope.minDate = moment(scope.minDate, scope.dateFormat)
+      if scope.utcMode then scope.minDate.utc()
+    if scope.maxDate
+      scope.maxDate = moment(scope.maxDate, scope.dateFormat)
+      if scope.utcMode then scope.maxDate.utc()
     if !scope.calendarHeader then scope.calendarHeader = {
       monday: $filter('date')(new Date(moment().isoWeekday(1)), 'EEE'),
       tuesday: $filter('date')(new Date(moment().isoWeekday(2)), 'EEE'),
@@ -115,6 +121,7 @@ app.directive('mbDatepicker', ['$filter', ($filter)->
       # Iterate over other dates
       for day in [0..monthLength]
         start = moment(startDay)
+        if scope.utcMode then start.utc()
         newDate = start.add(day, 'd')
         day = {date: newDate, value: newDate.format('DD')};
         if(scope.minDate and moment(newDate, scope.dateFormat) <= moment(scope.minDate, scope.dateFormat))
@@ -242,7 +249,10 @@ app.directive('mbDatepicker', ['$filter', ($filter)->
 
     init = ->
 # First day of month
-      firstMonday = moment(moment().date(today.month())).startOf('isoweek')
+      if scope.utcMode
+        firstMonday = moment(moment().utc().date(today.month())).startOf('isoweek')
+      else
+        firstMonday = moment(moment().date(today.month())).startOf('isoweek')
       if(firstMonday.date() == 1) then firstMonday.subtract(1, 'weeks')
 
       # No. of days in month

--- a/build/mbdatepicker.js
+++ b/build/mbdatepicker.js
@@ -50,7 +50,8 @@
           inputName: '@',
           placeholder: '@',
           arrows: '=?',
-          calendarHeader: '=?'
+          calendarHeader: '=?',
+          utcMode: '='
         },
         template: '<div id="dateSelectors" class="date-selectors"  outside-click="hidePicker()"> <input name="{{ inputName }}" type="text" class="mb-input-field"  ng-click="showPicker()"  class="form-control"  ng-model="date" placeholder="{{ placeholder }}"> <div class="mb-datepicker" ng-show="isVisible"> <table> <caption> <div class="header-year-wrapper"> <span style="display: inline-block; float: left; padding-left:20px; cursor: pointer" class="noselect" ng-click="previousYear(currentDate)"><img style="height: 10px;" ng-src="{{ arrows.year.left }}"/></span> <span class="header-year noselect" ng-class="noselect">{{ year }}</span> <span style="display: inline-block; float: right; padding-right:20px; cursor: pointer" class="noselect" ng-click="nextYear(currentDate)"><img style="height: 10px;" ng-src="{{ arrows.year.right }}"/></span> </div> <div class="header-nav-wrapper"> <span class="header-item noselect" style="float: left; cursor:pointer" ng-click="previousMonth(currentDate)"><img style="height: 10px;" ng-src="{{ arrows.month.left }}"/></span> <span class="header-month noselect">{{ month }}</span> <span class="header-item header-right noselect" style="float: right; cursor:pointer" ng-click="nextMonth(currentDate)"> <img style="height: 10px;" ng-src="{{ arrows.month.right }}"/></span> </div> </caption> <tbody> <tr> <td class="day-head">{{ ::calendarHeader.monday }}</td> <td class="day-head">{{ ::calendarHeader.tuesday }}</td> <td class="day-head">{{ ::calendarHeader.wednesday }}</td> <td class="day-head">{{ ::calendarHeader.thursday }}</td> <td class="day-head">{{ ::calendarHeader.friday }}</td> <td class="day-head">{{ ::calendarHeader.saturday }}</td> <td class="day-head">{{ ::calendarHeader.sunday }}</td> </tr> <tr class="days" ng-repeat="week in weeks"> <td ng-click="selectDate(day)" class="noselect" ng-class="::day.class" ng-repeat="day in week"> {{ ::day.value }} </td> </tr> </tbody> </table> </div> </div>',
         restrict: 'E',
@@ -59,6 +60,9 @@
           var getWeeks, init, selectors, today;
           selectors = document.querySelector('#dateSelectors');
           today = moment();
+          if (scope.utcMode) {
+            today.utc();
+          }
           scope.month = '';
           scope.year = today.year();
           if (scope.inputClass) {
@@ -69,9 +73,15 @@
           }
           if (scope.minDate) {
             scope.minDate = moment(scope.minDate, scope.dateFormat);
+            if (scope.utcMode) {
+              scope.minDate.utc();
+            }
           }
           if (scope.maxDate) {
             scope.maxDate = moment(scope.maxDate, scope.dateFormat);
+            if (scope.utcMode) {
+              scope.maxDate.utc();
+            }
           }
           if (!scope.calendarHeader) {
             scope.calendarHeader = {
@@ -101,6 +111,9 @@
             monthDays = [];
             for (day = j = 0, ref = monthLength; 0 <= ref ? j <= ref : j >= ref; day = 0 <= ref ? ++j : --j) {
               start = moment(startDay);
+              if (scope.utcMode) {
+                start.utc();
+              }
               newDate = start.add(day, 'd');
               day = {
                 date: newDate,
@@ -221,7 +234,11 @@
           };
           init = function() {
             var days, endDate, firstMonday;
-            firstMonday = moment(moment().date(today.month())).startOf('isoweek');
+            if (scope.utcMode) {
+              firstMonday = moment(moment().utc().date(today.month())).startOf('isoweek');
+            } else {
+              firstMonday = moment(moment().date(today.month())).startOf('isoweek');
+            }
             if (firstMonday.date() === 1) {
               firstMonday.subtract(1, 'weeks');
             }


### PR DESCRIPTION
By default, `moment` uses the local timezone of the user. In many cases this is desired behaviour, _unless_ you want to share a fixed date, which should be independent of timezone, with users that reside in different timezones.

An example of such a fixed date is a birth date. If I'm in timezone UTC+2 and I choose the date January 1st, 2015, then my birth date should _not_ change to December 31, 2014 if viewed by another user in timezone UTC-7. To prevent that, this pull request offers support for UTC mode.

(In other cases, for example, the date of an event at a specific location, the current behaviour which shows date in the local timezone is desired.)

### Implementation
If UTC mode is on, `utc()` is called on each new date generated by `moment()`. UTC mode is optional, so it's not a breaking change.

### Usage

By default UTC mode is turned off, so then the functionality is the same as before. To enable UTC mode, one can add `utc-mode="true"` to `<mb-datepicker>`.