### PR TITLE
Bug fix: calculation of first monday

### DIFF
--- a/app/scripts/mbdatepicker.coffee
+++ b/app/scripts/mbdatepicker.coffee
@@ -242,7 +242,7 @@ app.directive('mbDatepicker', ['$filter', ($filter)->
 
     init = ->
 # First day of month
-      firstMonday = moment(moment().date(today.month())).startOf('isoweek')
+      firstMonday = moment(moment().date(1)).startOf('isoweek')
       if(firstMonday.date() == 1) then firstMonday.subtract(1, 'weeks')
 
       # No. of days in month

--- a/build/mbdatepicker.js
+++ b/build/mbdatepicker.js
@@ -221,7 +221,7 @@
           };
           init = function() {
             var days, endDate, firstMonday;
-            firstMonday = moment(moment().date(today.month())).startOf('isoweek');
+            firstMonday = moment(moment().date(1)).startOf('isoweek');
             if (firstMonday.date() === 1) {
               firstMonday.subtract(1, 'weeks');
             }


### PR DESCRIPTION
When the current month is between August (> 7) and December, the first week of the month is not shown when you first open the datepicker.

In the original code it did the following: `moment().date(today.month())`

However, `today.month()` is the _number of the month_. And `date()` is a setter for the _day of the month_.

So in October you get the following date: 10 October.
In November you would get: 11 November.

And then if you take the start of the isoweek relative to 10 October, you get 5 October as the "first" monday.

As a result the first week was not shown in the datepicker when you first opened it. Of course it worked fine up until July, because then the number of the month is <= 7.